### PR TITLE
fix: Correct recordId handling in admin and add version number

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3,13 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Admin Ticket Dashboard</title>
+    <title>V0.1.1 - Admin Ticket Dashboard</title>
     <link rel="stylesheet" href="css/style.css">
     <!-- <link rel="stylesheet" href="css/admin-style.css"> --> <!-- Optional: for separate admin styles -->
 </head>
 <body>
     <div class="container dashboard-container">
-        <h1>Ticket Management Dashboard</h1>
+        <div class="dashboard-header">
+            <h1>Ticket Management Dashboard</h1>
+            <span class="version-number">V0.1.1</span>
+        </div>
 
         <div id="adminMessageArea" class="message-area" style="display:none;">Loading tickets...</div>
 
@@ -78,7 +81,7 @@
                 <p><strong>Assigned Collaborator:</strong> <span id="modalTicketAssignee"></span></p>
                 <p><strong>Submission Date:</strong> <span id="modalTicketSubmissionDate"></span></p>
                 <p><strong>Attachment:</strong> <span id="modalTicketAttachment"></span></p>
-                
+
                 <hr>
                 <h3>Update Ticket</h3>
                 <div class="form-group">

--- a/css/style.css
+++ b/css/style.css
@@ -112,6 +112,26 @@ button[type="submit"]:hover {
 
 
 /* Admin Dashboard Specific Styles */
+.dashboard-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between; /* Pushes version number to the right */
+    margin-bottom: 20px; /* Same as h1 original margin-bottom */
+}
+
+.dashboard-header h1 {
+    margin-bottom: 0; /* Remove bottom margin as it's now on dashboard-header */
+}
+
+.version-number {
+    font-size: 0.85em;
+    color: #666;
+    background-color: #f0f0f0;
+    padding: 3px 6px;
+    border-radius: 4px;
+    align-self: flex-start; /* Align with top of h1 if h1 is larger */
+}
+
 .dashboard-container {
     max-width: 1200px; /* Wider container for dashboard */
     margin: 20px auto; /* More margin for dashboard */
@@ -239,7 +259,7 @@ button[type="submit"]:hover {
 /* Ensure general .container styles don't conflict too much with .dashboard-container */
 .container {
     /* This was for the form page, dashboard uses .dashboard-container */
-    /* max-width: 600px; */ 
+    /* max-width: 600px; */
 }
 
 /* Remove the old .dashboard placeholder if it exists */

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <div class="container">
         <h1>Submit a New Support Ticket</h1>
-        
+
         <div id="userMessageArea" class="message-area" style="display:none;"></div>
 
         <form id="ticketForm">

--- a/js/airtable-api.js
+++ b/js/airtable-api.js
@@ -51,7 +51,7 @@ async function _fetchAirtableAPI(recordIdOrQuery = '', method, body = null) {
              url += `/${recordIdOrQuery}`;
         }
     }
-    
+
     const headers = {
         'Authorization': `Bearer ${AIRTABLE_API_TOKEN}`,
         'Content-Type': 'application/json'
@@ -99,9 +99,9 @@ async function _fetchAirtableAPI(recordIdOrQuery = '', method, body = null) {
 
         if (response.status === 204 || response.headers.get("content-length") === "0") {
             console.log("[Airtable API] Response is 204 No Content or empty.");
-            return null; 
+            return null;
         }
-        
+
         const jsonData = await response.json();
         console.log("[Airtable API] Parsed JSON Data from response:", jsonData);
         return jsonData;
@@ -192,7 +192,7 @@ async function createTicket(ticketDataFromForm) {
         console.log('[Airtable API] createTicket: Attempting to create record with data:', JSON.stringify(requestBody, null, 2));
         // Airtable returns the created record object directly (not in an array like Stackby for single creation)
         const createdRecord = await _fetchAirtableAPI('', 'POST', requestBody);
-        
+
         if (createdRecord && createdRecord.id) {
             console.log('[Airtable API] createTicket: Ticket created successfully. Result:', JSON.stringify(createdRecord, null, 2));
             // Adapt to expected structure (id instead of rowId, fields object)
@@ -221,7 +221,7 @@ async function getAllTickets() {
         // Airtable returns records in a 'records' array
         // Removed the '?view=All%20Tickets' parameter to fetch all records without specifying a view.
         // Other query parameters like sort can be added here if needed, e.g., '?sort%5B0%5D%5Bfield%5D=Created&sort%5B0%5D%5Bdirection%5D=desc'
-        const response = await _fetchAirtableAPI('', 'GET'); 
+        const response = await _fetchAirtableAPI('', 'GET');
         if (response && response.records) {
             console.log('[Airtable API] getAllTickets: Tickets fetched successfully. Count:', response.records.length);
             // Adapt each record to have 'id' and 'fields' at top level, and 'created_at' from 'createdTime'
@@ -283,7 +283,7 @@ async function updateTicket(recordId, updatedDataFromApp) {
         console.error('[Airtable API] updateTicket: Record ID is required.');
         return null;
     }
-    
+
     const fieldsToUpdate = { ...updatedDataFromApp };
 
     // Handle attachment if present in updatedDataFromApp
@@ -300,7 +300,7 @@ async function updateTicket(recordId, updatedDataFromApp) {
         } else if (attachmentValue === '' || attachmentValue === null) {
             // To clear an attachment field in Airtable, you might need to pass null or an empty array
             // depending on the field type and API behavior. For attachment fields, null is often used.
-            fieldsToUpdate[COLUMN_NAMES.ATTACHMENT] = null; 
+            fieldsToUpdate[COLUMN_NAMES.ATTACHMENT] = null;
         }
         // If attachmentValue is already an array of objects, assume it's correctly formatted
     }

--- a/js/main.js
+++ b/js/main.js
@@ -100,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 ticketData[COLUMN_NAMES.ATTACHMENT] = [{ url: attachmentUrlValue }];
             }
             // If attachmentUrlValue is empty, the ATTACHMENT field will be omitted from ticketData.
-            
+
             // Perform validation (Note: Attachment URL is optional, so not validated here for presence)
             if (!validateForm(ticketData)) {
                 showMessage('Please correct the errors in the form.', 'error');
@@ -108,7 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             console.log('Form validated successfully. Preparing data for Stackby:', ticketData);
-            
+
             // Disable button to prevent multiple submissions
             const submitButton = ticketForm.querySelector('button[type="submit"]');
             submitButton.disabled = true;
@@ -116,10 +116,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
             try {
                 const result = await createTicket(ticketData); // createTicket is from stackby-api.js
-                
+
                 // Corrected check: Stackby returns the created row object directly, which has a top-level 'rowId'.
                 // The success check now uses 'id' which is what Airtable returns as the record ID.
-                if (result && result.id) { 
+                if (result && result.id) {
                     // For display, prefer a user-defined "Ticket ID" field if it exists in result.fields, otherwise fallback to Airtable record ID.
                     const displayId = (result.fields && result.fields[COLUMN_NAMES.TICKET_ID]) || result.id;
                     showMessage(`Ticket submitted successfully! Your Ticket ID is: ${displayId}. You will receive an email confirmation shortly (placeholder).`, 'success');


### PR DESCRIPTION
- js/admin.js:
  - Correctly use ticket.id (Airtable record ID) instead of ticket.rowId.
  - Ensure valid recordId is passed to openTicketDetailModal.
  - Use this recordId for getTicketById and updateTicket operations.
  - Corrected findIndex in update handlers to use t.id.
  - Adjusted access to 'created_at' to be ticket.created_at.
- admin.html:
  - Added version number V0.1.1 to the <title> tag.
  - Added a visible version number V0.1.1 next to the main header.
- css/style.css:
  - Added styles for the new version number display.