### PR TITLE
fix: Correct handling of pre-formatted attachment objects in API module

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>V0.2.0 - Admin Ticket Dashboard</title>
+    <title>V0.2.1 - Admin Ticket Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {
@@ -24,7 +24,7 @@
     <div class="max-w-6xl mx-auto bg-white p-6 rounded-lg shadow-lg">
         <div class="flex justify-between items-center mb-6">
             <h1 class="text-3xl font-bold text-gray-700">Ticket Management Dashboard</h1>
-            <span class="text-sm text-gray-500 bg-gray-200 px-2 py-1 rounded-full">V0.2.0</span>
+            <span class="text-sm text-gray-500 bg-gray-200 px-2 py-1 rounded-full">V0.2.1</span>
         </div>
 
         <!-- Message Area: Will be styled with Tailwind classes directly in JS or kept if custom styles are preferred -->


### PR DESCRIPTION
- Resolved "attachmentValue.startsWith is not a function" error.
- Modified js/airtable-api.js (createTicket and updateTicket) to correctly use the pre-formatted attachment object ([{url: '...'}]) received from js/main.js without attempting to re-process it as a string.
- Updated version in admin.html to V0.2.1.