### PR TITLE
fix: Improve modal horizontal centering and update version

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>V0.3.0 - Admin Ticket Dashboard</title>
+    <title>V0.3.1 - Admin Ticket Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
@@ -36,7 +36,7 @@
         <div class="flex justify-between items-center mb-6">
             <h1 class="text-3xl font-title text-neon-pink font-bold">Ticket Management Dashboard</h1>
             <div class="flex items-center space-x-4">
-                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V0.3.0</span>
+                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V0.3.1</span>
                 <button id="logoutButton" class="font-title text-xs px-3 py-1 bg-transparent border border-neon-pink text-neon-pink hover:bg-neon-pink hover:text-dark-bg font-semibold rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-neon-pink focus:ring-offset-slate-900">Logout</button>
             </div>
         </div>
@@ -99,12 +99,12 @@
     </div>
 
     <!-- Ticket Detail Modal -->
-    <div id="ticketDetailModal" class="fixed z-10 inset-0 hidden items-center justify-center p-4">
+    <div id="ticketDetailModal" class="fixed z-10 inset-0 hidden flex items-center p-4">
         <!-- Background overlay -->
         <div class="fixed inset-0 bg-black bg-opacity-75 backdrop-blur-sm transition-opacity" aria-hidden="true"></div>
 
         <!-- Modal panel -->
-        <div class="relative bg-slate-900 rounded-lg text-left overflow-hidden shadow-[0_0_20px_rgba(249,0,249,0.6)] border border-neon-pink transform transition-all w-full sm:max-w-2xl max-h-[90vh] flex flex-col">
+        <div class="relative bg-slate-900 rounded-lg text-left overflow-hidden shadow-[0_0_20px_rgba(249,0,249,0.6)] border border-neon-pink transform transition-all w-full sm:max-w-2xl mx-auto max-h-[90vh] flex flex-col">
             <!-- Modal Header -->
             <div class="px-4 pt-5 pb-4 sm:p-6 sm:pb-4 border-b border-slate-700">
                 <div class="flex items-start justify-between">


### PR DESCRIPTION
I've adjusted the Tailwind CSS classes for the ticket detail modal in `admin.html`:
- I removed `justify-center` from the main modal container (`#ticketDetailModal`).
- I added `mx-auto` to the modal panel to ensure it centers itself horizontally. This should provide more robust centering, especially on large viewports.

I also updated the version number in the `admin.html` title and header to V0.3.1.