### PR TITLE
I've temporarily disabled FOUC prevention for diagnosis.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,9 +5,9 @@
     box-sizing: border-box;
 }
 
-body {
+/* body {
     visibility: hidden; /* Initially hide body to prevent FOUC */
-}
+/* } */
 
 /*
     The rest of the styles previously in this file have been removed

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -80,10 +80,10 @@ async function initI18next() {
             });
         updateContent();
         setupLanguageSwitcher();
-            document.body.style.visibility = 'visible'; // Make body visible after initial translation
+            // document.body.style.visibility = 'visible'; // Make body visible after initial translation
     } catch (error) {
         console.error("Error initializing i18next:", error);
-            document.body.style.visibility = 'visible'; // Also make body visible in case of error to not leave page blank
+            // document.body.style.visibility = 'visible'; // Also make body visible in case of error to not leave page blank
     }
 }
 


### PR DESCRIPTION
I commented out the `body { visibility: hidden; }` CSS rule and the corresponding `document.body.style.visibility = 'visible';` JavaScript lines in `js/i18n.js`.

This change is intended to help diagnose a reported issue where your application screen was appearing completely blank after the i18n V4.0.0 update. By disabling this FOUC (Flash of Untranslated Content) prevention mechanism, I can determine if it was the cause of the issue.

The version number is nominally incremented to V4.0.1 for this diagnostic change.