### PR TITLE
fix: Correct status i18n key generation, prep for further debug

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>V4.0.2 - Admin Ticket Dashboard</title> <!-- Fallback title -->
+    <title>V4.0.3 - Admin Ticket Dashboard</title> <!-- Fallback title -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
@@ -43,7 +43,7 @@
         <div class="flex justify-between items-center mb-6">
             <h1 data-i18n="adminDashboardTitle" class="text-3xl font-title text-neon-pink font-bold">Ticket Management Dashboard</h1>
             <div class="flex items-center space-x-4">
-                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V4.0.2</span>
+                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V4.0.3</span>
                 <button id="logoutButton" data-i18n="adminPage.logoutButton" class="font-title text-xs px-3 py-1 bg-transparent border border-neon-pink text-neon-pink hover:bg-neon-pink hover:text-dark-bg font-semibold rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-neon-pink focus:ring-offset-slate-900">Logout</button>
             </div>
         </div>

--- a/js/admin.js
+++ b/js/admin.js
@@ -212,9 +212,27 @@ document.addEventListener('DOMContentLoaded', async () => {
             row.insertCell().outerHTML = `<td class="px-6 py-4 whitespace-nowrap text-sm"><span class="${urgencyFinalClass}">${urgencyIcon}${translatedUrgency}</span></td>`;
 
             const statusValue = fields[COLUMN_NAMES.STATUS] || 'New';
-            const statusKey = `commonStatuses.${statusValue.toLowerCase().replace(/\s+/g, '')}`;
+            let formattedStatusValue;
+            if (statusValue === 'In Progress') {
+                formattedStatusValue = 'inProgress';
+            } else if (statusValue === 'Acknowledged') {
+                formattedStatusValue = 'acknowledged';
+            } else if (statusValue === 'Resolved') {
+                formattedStatusValue = 'resolved';
+            } else if (statusValue === 'Pending') {
+                formattedStatusValue = 'pending';
+            } else if (statusValue === 'Closed') {
+                formattedStatusValue = 'closed';
+            } else if (statusValue === 'New') {
+                formattedStatusValue = 'new';
+            } else {
+                // Fallback for any other status: simple lowercase, no space removal.
+                // This might need adjustment if other multi-word statuses exist and need specific keys.
+                formattedStatusValue = statusValue.toLowerCase().replace(/\s+/g, '');
+            }
+            const statusKey = `commonStatuses.${formattedStatusValue}`;
             console.log(`[admin] Translating status: value='${statusValue}', key='${statusKey}'`);
-            const translatedStatus = i18next.t(statusKey, { defaultValue: statusValue });
+            const translatedStatus = i18next.t(statusKey, { defaultValue: statusValue }); // defaultValue already added in previous step, this confirms it.
             console.log(`[admin] Translated status: '${translatedStatus}'`);
             let statusBadgeClasses = 'px-2 inline-flex text-xs leading-5 font-semibold rounded-full border';
             if (statusValue === 'New') statusBadgeClasses += ' border-neon-blue text-neon-blue';


### PR DESCRIPTION
This commit includes:
- Corrected i18n key generation for status values in `js/admin.js` within the `renderTickets` function to properly match keys like `commonStatuses.inProgress`.
- Confirmed that `defaultValue` options for `i18next.t()` calls for status and urgency were already in place in `js/admin.js`.
- Updated version number in `admin.html` to V4.0.3.

Extensive console logging remains from previous steps to help diagnose why translations for seemingly correct keys (like commonUrgencies.normal, commonStatuses.new, commonStatuses.closed) are still reportedly resolving to the string 'undefined'.

The FOUC prevention mechanism remains disabled.