### PR TITLE
fix: Resolve 'setLanguage is not defined' error for i18n switcher

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>V0.5.0 - Admin Ticket Dashboard</title> <!-- Fallback title -->
+    <title>V0.5.1 - Admin Ticket Dashboard</title> <!-- Fallback title -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
@@ -41,7 +41,7 @@
         <div class="flex justify-between items-center mb-6">
             <h1 data-i18n-static="adminPage.header" class="text-3xl font-title text-neon-pink font-bold">Ticket Management Dashboard</h1>
             <div class="flex items-center space-x-4">
-                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V0.5.0</span>
+                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V0.5.1</span>
                 <button id="logoutButton" data-i18n-static="adminPage.logoutButton" class="font-title text-xs px-3 py-1 bg-transparent border border-neon-pink text-neon-pink hover:bg-neon-pink hover:text-dark-bg font-semibold rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-neon-pink focus:ring-offset-slate-900">Logout</button>
             </div>
         </div>

--- a/js/i18n-static.js
+++ b/js/i18n-static.js
@@ -139,7 +139,7 @@ const translations = {
 
 let currentLanguage = localStorage.getItem('selectedLanguage') || 'en';
 
-function setLanguage(lang) {
+window.setLanguage = function(lang) {
     if (translations[lang]) {
         currentLanguage = lang;
         localStorage.setItem('selectedLanguage', lang);


### PR DESCRIPTION
I modified `js/i18n-static.js` to ensure the `setLanguage` function is globally accessible by assigning it to `window.setLanguage`. This corrects the `ReferenceError: setLanguage is not defined` that occurred when you clicked the language switcher buttons, which use inline `onclick="setLanguage(...)"` attributes.

The language switcher should now function as you expected.

I updated the version in `admin.html` to V0.5.1.