### PR TITLE
feat: Implement Google Translate Widget for EN/FR translation

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>V0.3.1 - Admin Ticket Dashboard</title>
+    <title>V0.6.0 - Admin Ticket Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
@@ -32,11 +32,13 @@
     <!-- <link rel="stylesheet" href="css/admin-style.css"> -->
 </head>
 <body class="bg-dark-bg text-text-light font-sans p-4">
+    <div id="google_translate_element" style="position: fixed; top: 10px; right: 10px; z-index: 1000;"></div>
+
     <div class="max-w-6xl mx-auto bg-slate-900 p-6 rounded-lg shadow-[0_0_15px_rgba(0,240,240,0.5)] border border-neon-blue">
         <div class="flex justify-between items-center mb-6">
             <h1 class="text-3xl font-title text-neon-pink font-bold">Ticket Management Dashboard</h1>
             <div class="flex items-center space-x-4">
-                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V0.3.1</span>
+                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V0.6.0</span>
                 <button id="logoutButton" class="font-title text-xs px-3 py-1 bg-transparent border border-neon-pink text-neon-pink hover:bg-neon-pink hover:text-dark-bg font-semibold rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-neon-pink focus:ring-offset-slate-900">Logout</button>
             </div>
         </div>
@@ -174,5 +176,15 @@
 
     <script src="js/airtable-api.js"></script>
     <script src="js/admin.js"></script>
+    <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({
+        pageLanguage: 'en',
+        includedLanguages: 'en,fr',
+        // layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+      }, 'google_translate_element');
+    }
+    </script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body class="bg-dark-bg text-text-light font-sans flex items-center justify-center min-h-screen">
+    <div id="google_translate_element" style="position: fixed; top: 10px; right: 10px; z-index: 1000;"></div>
+
     <div class="bg-slate-900 p-8 rounded-lg shadow-[0_0_15px_rgba(0,240,240,0.5)] border border-neon-blue w-full max-w-lg">
         <h1 class="text-2xl font-title text-neon-pink font-bold text-center mb-6">Submit a New Support Ticket</h1>
 
@@ -85,5 +87,15 @@
 
     <script src="js/airtable-api.js"></script>
     <script src="js/main.js"></script>
+    <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({
+        pageLanguage: 'en',
+        includedLanguages: 'en,fr',
+        // layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+      }, 'google_translate_element');
+    }
+    </script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" data-i18n-page-title-static="loginPage.title">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login - Support Ticket System</title> <!-- Fallback title -->
+    <title>Login - Support Ticket System</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
@@ -31,13 +31,10 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body class="bg-dark-bg text-text-light font-sans flex items-center justify-center min-h-screen">
-    <div class="lang-switcher-static fixed top-4 right-4 z-50 space-x-1 p-1 bg-slate-800 rounded-md shadow-lg">
-        <button data-lang="en" onclick="setLanguage('en')" class="px-3 py-1 text-xs bg-slate-700 hover:bg-slate-600 text-white rounded disabled:opacity-50" data-i18n-static="langSwitcherEN">EN</button>
-        <button data-lang="fr" onclick="setLanguage('fr')" class="px-3 py-1 text-xs bg-slate-700 hover:bg-slate-600 text-white rounded disabled:opacity-50" data-i18n-static="langSwitcherFR">FR</button>
-    </div>
+    <div id="google_translate_element" style="position: fixed; top: 10px; right: 10px; z-index: 1000;"></div>
 
     <div class="bg-slate-900 p-8 rounded-lg shadow-[0_0_15px_rgba(0,240,240,0.5)] border border-neon-blue w-full max-w-lg">
-        <h1 data-i18n-static="loginPage.header" class="text-2xl font-title text-neon-pink font-bold text-center mb-6">User Login</h1>
+        <h1 class="text-2xl font-title text-neon-pink font-bold text-center mb-6">User Login</h1>
 
         <div id="loginMessageArea" class="message-area mb-4 p-3 rounded-md text-center" style="display:none;">
             <!-- Messages will be displayed here -->
@@ -45,18 +42,18 @@
 
         <form id="loginForm" class="space-y-6">
             <div>
-                <label for="email" class="block text-sm font-medium text-neon-blue font-title" data-i18n-static="loginPage.emailLabel">Email</label>
+                <label for="email" class="block text-sm font-medium text-neon-blue font-title">Email</label>
                 <input type="email" id="email" name="email" required
                        class="mt-1 block w-full px-3 py-2 bg-slate-800 border border-neon-blue text-text-light rounded-md shadow-sm placeholder-text-medium focus:outline-none focus:ring-neon-pink focus:border-neon-pink sm:text-sm">
             </div>
 
             <div>
-                <label for="password" class="block text-sm font-medium text-neon-blue font-title" data-i18n-static="loginPage.passwordLabel">Password</label>
+                <label for="password" class="block text-sm font-medium text-neon-blue font-title">Password</label>
                 <input type="password" id="password" name="password" required
                        class="mt-1 block w-full px-3 py-2 bg-slate-800 border border-neon-blue text-text-light rounded-md shadow-sm placeholder-text-medium focus:outline-none focus:ring-neon-pink focus:border-neon-pink sm:text-sm">
             </div>
 
-            <button type="submit" data-i18n-static="loginPage.loginButton"
+            <button type="submit"
                     class="w-full flex justify-center py-2 px-4 font-title border-2 border-neon-pink text-neon-pink hover:bg-neon-pink hover:text-dark-bg font-semibold rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-neon-pink focus:ring-offset-dark-bg disabled:opacity-50">
                 Login
             </button>
@@ -65,7 +62,16 @@
 
     <script src="js/airtable-api.js"></script>
     <script src="js/login.js"></script>
-    <script src="js/i18n-static.js"></script>
+    <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({
+        pageLanguage: 'en',
+        includedLanguages: 'en,fr',
+        // layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+      }, 'google_translate_element');
+    }
+    </script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
     <!-- css/style.css is already linked in the head -->
 </body>
 </html>


### PR DESCRIPTION
This commit introduces the Google Translate Website Translator widget as the new internationalization (i18n) solution. This replaces all previous custom i18n attempts.

Key Changes:

1.  **Revert of Previous i18n Systems:**
    *   All code and assets related to the i18next-based system (V4.x.x) and the subsequent custom static JavaScript i18n system (V0.5.x) were removed in preceding commits, establishing a baseline equivalent to V0.3.1.

2.  **Google Translate Widget Integration:**
    *   Added the Google Translate Widget HTML (`<div id="google_translate_element">...</div>`) to `index.html`, `admin.html`, and `login.html`. The widget is styled with fixed positioning for consistent top-right placement.
    *   Added the Google Translate initialization JavaScript snippet to all three HTML files.
    *   The widget is configured with English (`en`) as the page's source language and is set to offer translation primarily between English and French (`includedLanguages: 'en,fr'`).

3.  **Scope:**
    *   The Google Translate Widget will attempt to translate text content across the site as per its default behavior. This may include static text, dynamically generated JavaScript messages, and data fetched from APIs that is rendered as text. Specific element-level control over what is translated is limited with this widget.

4.  **Versioning:**
    *   Updated the application version displayed in `admin.html` to `V0.6.0`.