### PR TITLE
style: Adjust Google Translate Widget placement in admin header

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>V0.6.0 - Admin Ticket Dashboard</title>
+    <title>V0.6.1 - Admin Ticket Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
@@ -32,13 +32,12 @@
     <!-- <link rel="stylesheet" href="css/admin-style.css"> -->
 </head>
 <body class="bg-dark-bg text-text-light font-sans p-4">
-    <div id="google_translate_element" style="position: fixed; top: 10px; right: 10px; z-index: 1000;"></div>
-
     <div class="max-w-6xl mx-auto bg-slate-900 p-6 rounded-lg shadow-[0_0_15px_rgba(0,240,240,0.5)] border border-neon-blue">
         <div class="flex justify-between items-center mb-6">
             <h1 class="text-3xl font-title text-neon-pink font-bold">Ticket Management Dashboard</h1>
             <div class="flex items-center space-x-4">
-                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V0.6.0</span>
+                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V0.6.1</span>
+                <div id="google_translate_element"></div>
                 <button id="logoutButton" class="font-title text-xs px-3 py-1 bg-transparent border border-neon-pink text-neon-pink hover:bg-neon-pink hover:text-dark-bg font-semibold rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-neon-pink focus:ring-offset-slate-900">Logout</button>
             </div>
         </div>


### PR DESCRIPTION
I modified `admin.html` to improve the integration of the Google Translate Widget:
- I removed the fixed positioning from the widget's container div.
- I relocated the `<div id="google_translate_element"></div>` into the main header area, placing it between the version number display and the logout button.
- This allows the widget to be aligned with other header elements using existing flexbox styles.

I updated the version in `admin.html` to V0.6.1.