### PR TITLE
style: Configure Google Translate widget for minimal layout and attem…

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>V0.6.1 - Admin Ticket Dashboard</title>
+    <title>V0.6.2 - Admin Ticket Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
@@ -36,7 +36,7 @@
         <div class="flex justify-between items-center mb-6">
             <h1 class="text-3xl font-title text-neon-pink font-bold">Ticket Management Dashboard</h1>
             <div class="flex items-center space-x-4">
-                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V0.6.1</span>
+                <span class="text-xs font-semibold text-dark-bg bg-neon-blue px-2 py-1 rounded-full">V0.6.2</span>
                 <div id="google_translate_element"></div>
                 <button id="logoutButton" class="font-title text-xs px-3 py-1 bg-transparent border border-neon-pink text-neon-pink hover:bg-neon-pink hover:text-dark-bg font-semibold rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-neon-pink focus:ring-offset-slate-900">Logout</button>
             </div>
@@ -180,7 +180,7 @@
       new google.translate.TranslateElement({
         pageLanguage: 'en',
         includedLanguages: 'en,fr',
-        // layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+        layout: google.translate.TranslateElement.InlineLayout.SIMPLE
       }, 'google_translate_element');
     }
     </script>

--- a/css/style.css
+++ b/css/style.css
@@ -9,6 +9,62 @@
     visibility: hidden; /* Initially hide body to prevent FOUC */
 /* } */
 
+/* Attempt to hide Google Translate attribution text and branding */
+
+/* Hide the main banner frame if it appears */
+iframe.goog-te-banner-frame {
+    display: none !important;
+}
+
+/* Hide the text element often containing "Powered by" within the simple layout */
+.goog-te-gadget-simple span[style*="text-decoration:none"] {
+    display: none !important;
+}
+
+/* Hide the Google logo that might appear in some widget variations */
+.goog-logo-link {
+    display: none !important;
+}
+
+img.goog-logo-link {
+    display: none !important;
+}
+
+/* Hide the general "Powered by" text container if it's outside the main gadget span */
+.goog-te-gadget-icon { /* This may hide the icon too, adjust if needed */
+    display: none !important;
+}
+
+/* Hide the tooltip balloon that can show "Original text" or attribution */
+#goog-gt-tt, .goog-te-balloon-frame {
+    display: none !important;
+}
+
+/* Hide the "Skip to main content" link sometimes added by Google's scripts */
+body > .skiptranslate {
+    display: none !important;
+    visibility: hidden !important; /* Extra measures */
+    height: 0px !important;
+    width: 0px !important;
+    overflow: hidden !important;
+}
+
+/* If the simple layout still shows a small Google icon next to the language */
+#google_translate_element .goog-te-gadget-simple .goog-te-menu-value img {
+    display: none !important;
+}
+#google_translate_element .goog-te-gadget-simple span {
+    padding-right: 5px !important; /* Adjust padding if icon is removed */
+}
+
+/* A more aggressive attempt to hide the text if it's within a specific structure */
+.goog-te-gadget-simple > span > a {
+    display: none !important; /* This might hide the language text too, be careful */
+}
+/* If the above hides language text, try to be more specific if Google uses a particular class for attribution links */
+/* .goog-te-gadget-simple > span > a.google-attribution-link { display: none !important; } */
+
+
 /*
     The rest of the styles previously in this file have been removed
     as they are now handled by Tailwind CSS utility classes applied

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
       new google.translate.TranslateElement({
         pageLanguage: 'en',
         includedLanguages: 'en,fr',
-        // layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+        layout: google.translate.TranslateElement.InlineLayout.SIMPLE
       }, 'google_translate_element');
     }
     </script>

--- a/login.html
+++ b/login.html
@@ -67,7 +67,7 @@
       new google.translate.TranslateElement({
         pageLanguage: 'en',
         includedLanguages: 'en,fr',
-        // layout: google.translate.TranslateElement.InlineLayout.SIMPLE
+        layout: google.translate.TranslateElement.InlineLayout.SIMPLE
       }, 'google_translate_element');
     }
     </script>


### PR DESCRIPTION
…pt to hide attribution

This commit applies changes to customize the appearance of the Google Translate Widget:

1.  **Minimal Layout:**
    *   Updated the widget initialization script in `index.html`, `admin.html`, and `login.html` to use `layout: google.translate.TranslateElement.InlineLayout.SIMPLE`. This configures the widget to render in its most compact form.

2.  **Hide Attribution (Experimental):**
    *   Added CSS rules to `css/style.css` that attempt to hide the "Powered by Google Translate" attribution text and other Google branding elements within the widget. The effectiveness of these rules is subject to Google's widget rendering and may be fragile.

3.  **Versioning:**
    *   Updated the version in `admin.html` to `V0.6.2`.

These changes aim to provide a more streamlined and integrated appearance for the Google Translate widget.